### PR TITLE
Install fileicon on mac to set conquest app icon (BLD-6874)

### DIFF
--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -28,8 +28,8 @@
       # Python utilities
       - pyenv # In order to install multiple versions of python, as homebrew only brings in 'the latest'
       - conan@1
-      # The server is required to run csd_mariadb_databaselib testsuite
-      - mariadb
+      # To set conquest app icon
+      - fileicon
   when: not cpp_buildmachine
 
 - name: Link conan


### PR DESCRIPTION
macos 12 (unlike macos 10.15) doesn't come with system python with pyobjc so we can easily use the Python script with the Cocoa module. Use instead the fileicon utitlity.

See https://apple.stackexchange.com/questions/6901/how-can-i-change-a-file-or-folder-icon-using-the-terminal

Also remove mariadb as it's been remove our C++ codebase.